### PR TITLE
fix the appimage yml to use data.tar.zst instead of data.tar.xz

### DIFF
--- a/builder/customize.py
+++ b/builder/customize.py
@@ -397,7 +397,9 @@ def _apply_linux_launcher(src, env, app, log):
             f"    exec: usr/share/rustdesk/{bin_name}", log)
         sed(src, yml, "apps/rustdesk.png", f"apps/{bin_name}.png", log)
         sed(src, yml, "apps/rustdesk.svg", f"apps/{bin_name}.svg", log)
-        sed(src, yml, "tar -xvf ./data.tar.xz", "tar -xvf ./data.tar.zst")
+        old_tar = "tar -xvf ./data.tar.xz"
+        new_tar = 'for f in ./data.tar.zst ./data.tar.xz; do [ -f "$f" ] && tar -xvf "$f" && break; done'
+        sed(src, yml, old_tar, new_tar)
 
 
 def _apply_company(src, env, platform, log):

--- a/builder/customize.py
+++ b/builder/customize.py
@@ -397,6 +397,7 @@ def _apply_linux_launcher(src, env, app, log):
             f"    exec: usr/share/rustdesk/{bin_name}", log)
         sed(src, yml, "apps/rustdesk.png", f"apps/{bin_name}.png", log)
         sed(src, yml, "apps/rustdesk.svg", f"apps/{bin_name}.svg", log)
+        sed(src, yml, "tar -xvf ./data.tar.xz", "tar -xvf ./data.tar.zst")
 
 
 def _apply_company(src, env, platform, log):


### PR DESCRIPTION
I am not sure if this is something new with Ubuntu 26.04 or not, but the appimage will fail because the file does not exist. This may need some more testing on older/different versions of linux.

```
bsdtar -zxvf rustdesk.deb
x debian-binary
x control.tar.zst
x data.tar.zst
tar -xvf ./data.tar.xz
tar: ./data.tar.xz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

This PR changes the command from `tar -xvf ./data.tar.xz` to `tar -xvf ./data.tar.zst`